### PR TITLE
Fixed non-conformant data bitlength from 8bit to 7bit

### DIFF
--- a/source/StandardFirmata.cpp
+++ b/source/StandardFirmata.cpp
@@ -96,7 +96,7 @@ void powerOn(RTCDRV_TimerID_t id, void * user)
   if(power_struct.state == false){
     digitalWrite(SLEEP_PIN, 0);
     power_struct.state = true;
-    RTCDRV_StopTimer(id); 	
+    RTCDRV_StopTimer(id);
     RTCDRV_StartTimer(id, rtcdrvTimerTypeOneshot, power_struct.sleep_period, powerOn, NULL);
   }
   else {
@@ -390,7 +390,7 @@ void sysexCallback(byte command, byte argc, byte *argv)
         case BALENA_SLEEP:
           if (argc > 5) {
             power_struct.sleep_delay = argv[1] * (uint32_t) DELAY_MULTIPLIER; // in seconds
-            power_struct.sleep_period = (argv[5] << 24 | argv[4] << 16 | argv[3] << 8 | argv[2]) * (uint32_t) DELAY_MULTIPLIER; // in seconds
+            power_struct.sleep_period = (argv[5] << 21 | argv[4] << 14 | argv[3] << 7 | argv[2]) * (uint32_t) DELAY_MULTIPLIER; // in seconds
             if(argv[1] == 0){ // without delayed start
               digitalWrite(SLEEP_PIN, 0);
               power_struct.state = true;
@@ -552,6 +552,3 @@ int main(void)
 		  }
 	}
 }
-
-
-

--- a/source/StandardFirmata.cpp
+++ b/source/StandardFirmata.cpp
@@ -390,7 +390,10 @@ void sysexCallback(byte command, byte argc, byte *argv)
         case BALENA_SLEEP:
           if (argc > 5) {
             power_struct.sleep_delay = argv[1] * (uint32_t) DELAY_MULTIPLIER; // in seconds
-            power_struct.sleep_period = (argv[5] << 21 | argv[4] << 14 | argv[3] << 7 | argv[2]) * (uint32_t) DELAY_MULTIPLIER; // in seconds
+            power_struct.sleep_period = (((argv[5] << 21) & 0x01) | \
+                                        (argv[4] << 14) | \
+                                        (argv[3] << 7) | \
+                                        (argv[2])) * (uint32_t) DELAY_MULTIPLIER; // in seconds
             if(argv[1] == 0){ // without delayed start
               digitalWrite(SLEEP_PIN, 0);
               power_struct.state = true;


### PR DESCRIPTION
In the firmata specification, the most significant bit of every byte is '1' always for commands and '0' always for data. Data bytes are only ever 7 bits long.